### PR TITLE
Split forest into community and ITP 2025 sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -64,6 +64,58 @@
   color: #a33;
 }
 
+.forest-page {
+  width: 100vw;
+  height: 100vh;
+  overflow: auto;
+  padding: 0 100px 100px;
+  box-sizing: border-box;
+}
+
+.forest-section {
+  margin-bottom: 48px;
+}
+
+.forest-section:last-child {
+  margin-bottom: 0;
+}
+
+.forest-section-header {
+  padding: 24px 0 16px;
+  border-bottom: 1.5px solid #333;
+  margin-bottom: 0;
+}
+
+.forest-section-title {
+  font-family: monospace;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 0 0 8px;
+  color: #000;
+}
+
+.forest-section-description {
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 8px;
+  color: #333;
+  max-width: 640px;
+}
+
+.forest-section-count {
+  font-family: monospace;
+  font-size: 14px;
+  margin: 0;
+  color: #000;
+}
+
+.forest-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 0;
+}
+
 .menu-container {
   position: fixed;
   right: 20px;
@@ -103,9 +155,20 @@
     margin-top: 200px;
   }
 
+  .forest-page {
+    padding: 80px 20px 20px !important;
+  }
+
   .forest-grid {
     grid-template-columns: 1fr !important;
-    padding: 80px 20px 20px 20px !important;
+  }
+
+  .forest-section-header {
+    padding-top: 16px;
+  }
+
+  .forest-section-title {
+    font-size: 18px;
   }
 
   .home-header {

--- a/src/Forest.jsx
+++ b/src/Forest.jsx
@@ -82,6 +82,21 @@ function DeleteIcon() {
   );
 }
 
+function ForestSection({title, description, count, children}) {
+  return (
+    <section className="forest-section">
+      <header className="forest-section-header">
+        <h2 className="forest-section-title">{title}</h2>
+        <p className="forest-section-description">{description}</p>
+        <p className="forest-section-count">
+          {count} {count === 1 ? "tree" : "trees"}
+        </p>
+      </header>
+      <div className="forest-grid">{children}</div>
+    </section>
+  );
+}
+
 function ForestTreeCell({entry, isSelected, onClick, onDelete}) {
   const isOwn = entry.source === "community" && entry.browserId === getBrowserId();
 
@@ -218,6 +233,25 @@ export function Forest({
     alert("Cleared local storage.");
   };
 
+  function renderTreeCells(entries, indexOffset) {
+    return entries.map((entry, index) => {
+      const globalIndex = indexOffset + index;
+      return (
+        <ForestTreeCell
+          key={entry.source === "community" ? entry.id : entry.id || entry.name || globalIndex}
+          entry={entry}
+          isSelected={globalIndex === selectedIndex || entry.id === selectedId}
+          onClick={() => onClickTree(entry.id, globalIndex)}
+          onDelete={
+            entry.source === "community" && entry.browserId === getBrowserId()
+              ? () => onDeleteCommunityTree(entry.id)
+              : undefined
+          }
+        />
+      );
+    });
+  }
+
   const onUploadFile = () => {
     const file = document.createElement("input");
     file.type = "file";
@@ -285,31 +319,23 @@ export function Forest({
           {loadError}
         </p>
       )}
-      <div
-        className="forest-grid"
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
-          gap: "0px",
-          padding: "0px 100px 100px 100px",
-          width: "100vw",
-          height: "100vh",
-          overflow: "auto",
-        }}
-      >
-        {displayNames.map((entry, index) => (
-          <ForestTreeCell
-            key={entry.source === "community" ? entry.id : entry.id || entry.name || index}
-            entry={entry}
-            isSelected={index === selectedIndex}
-            onClick={() => onClickTree(entry.id, index)}
-            onDelete={
-              entry.source === "community" && entry.browserId === getBrowserId()
-                ? () => onDeleteCommunityTree(entry.id)
-                : undefined
-            }
-          />
-        ))}
+      <div className="forest-page">
+        {communityTrees.length > 0 && (
+          <ForestSection
+            title="Community Forest"
+            description="Trees added online by visitors. Type your name on the home page and press Add to Forest. Hover your tree (marked with *) to delete it."
+            count={communityTrees.length}
+          >
+            {renderTreeCells(communityTrees, 0)}
+          </ForestSection>
+        )}
+        <ForestSection
+          title="ITP Spring Show 2025"
+          description="Trees from Find Trees in Names at NYU ITP — names typed at the show and kept in the installation archive."
+          count={archiveNames.length}
+        >
+          {renderTreeCells(archiveNames, communityTrees.length)}
+        </ForestSection>
       </div>
       {selectedName && (
         <TreeModal name={selectedName.name} onClose={() => setSelectedId(null)} isAdmin={isAdmin} />


### PR DESCRIPTION
## Summary

- Split `/forest` into two labeled sections, each with a **title**, **description**, and **tree count**.
- **Community Forest** — shown only when there are Supabase community trees; explains how to add and delete (hover `*`).
- **ITP Spring Show 2025** — installation archive from `names.json`.

## Test plan

- [x] With community trees: both sections appear; counts match grids
- [x] With no community trees: only ITP 2025 section shows
- [x] Click trees in either section → modal still works
- [x] Delete own community tree; count updates
- [x] Mobile layout: section headers and grids readable


Made with [Cursor](https://cursor.com)