### PR TITLE
Fix mobile layout and Safari crypto.randomUUID crash

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -116,6 +116,25 @@
   gap: 0;
 }
 
+.tree-page {
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.tree-visual {
+  width: 480px;
+  height: 480px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 80%;
+}
+
 .menu-container {
   position: fixed;
   right: 20px;
@@ -138,25 +157,45 @@
 }
 
 @media (max-width: 768px) {
+  .tree-page {
+    height: 100vh;
+    height: 100dvh;
+    justify-content: flex-start;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 140px 16px 48px;
+  }
+
+  .tree-visual {
+    width: min(72vw, 320px);
+    height: min(72vw, 320px);
+    max-width: none;
+    flex-shrink: 0;
+  }
+
   .menu-container {
-    top: 50px;
+    top: max(24px, env(safe-area-inset-top, 0px));
     right: auto;
     left: 50%;
     transform: translateX(-50%);
     flex-direction: row;
     bottom: auto;
+    z-index: 10;
   }
 
   .action-buttons {
     flex-direction: column !important;
+    flex-shrink: 0;
+    padding-bottom: 24px;
   }
 
   .input-container {
-    margin-top: 200px;
+    margin-top: 28px;
+    margin-bottom: 12px;
   }
 
   .forest-page {
-    padding: 80px 20px 20px !important;
+    padding: calc(80px + env(safe-area-inset-top, 0px)) 20px 20px !important;
   }
 
   .forest-grid {
@@ -176,14 +215,16 @@
     top: 0;
     left: 0;
     right: 0;
-    height: 60px;
+    height: calc(60px + env(safe-area-inset-top, 0px));
+    padding-top: env(safe-area-inset-top, 0px);
     background-color: #fefaf1;
     border-bottom: 1.5px solid #000;
     z-index: 999;
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: 0 20px;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 
   .home-button-container {

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -134,15 +134,7 @@ export function Tree({isAdmin, onAdd, onAddCommunity, addError, isAdding, text, 
   }
 
   return (
-    <div
-      style={{
-        height: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
+    <div className="tree-page">
       <div
         className="input-container"
         style={{
@@ -180,16 +172,7 @@ export function Tree({isAdmin, onAdd, onAddCommunity, addError, isAdding, text, 
           </p>
         </div>
       </div>
-      <div
-        style={{
-          width: 480,
-          height: 480,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          maxWidth: "80%",
-        }}
-      >
+      <div className="tree-visual">
         <div
           ref={treeRef}
           style={{

--- a/src/lib/browserId.js
+++ b/src/lib/browserId.js
@@ -1,9 +1,32 @@
 const STORAGE_KEY = "name2tree_browser_id";
 
+function createId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // Non-secure contexts (e.g. HTTP on a LAN IP) can expose the API but throw.
+    }
+  }
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 export function getBrowserId() {
   let id = localStorage.getItem(STORAGE_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = createId();
     localStorage.setItem(STORAGE_KEY, id);
   }
   return id;


### PR DESCRIPTION
## Summary
- Give the mobile home page more space below the top menu and a smaller tree so the input is not cramped against the icons.
- Make the home page scrollable on mobile so Add to Forest / Explore Forest / Download are not clipped off-screen.
- Fall back when `crypto.randomUUID` is missing (e.g. Safari over HTTP on a LAN IP) so the Forest page no longer crashes.

## Test plan
- [ ] On a phone-width viewport, confirm clearer gap between top menu icons and the name input
- [ ] Type a name and confirm all three action buttons are reachable by scrolling
- [ ] Open Forest over HTTP (or Safari non-secure context) and confirm no `crypto.randomUUID` error
- [ ] Confirm desktop layout is unchanged


Made with [Cursor](https://cursor.com)