### PR TITLE
Limit forest enter animation to newly added trees

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
   const [text, setTextState] = useState("");
   const [archiveNames, setArchiveNames] = useState(initData);
   const [communityTrees, setCommunityTrees] = useState([]);
-  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [justAddedId, setJustAddedId] = useState(null);
   const [addError, setAddError] = useState("");
   const [isAdding, setIsAdding] = useState(false);
   const location = useLocation();
@@ -59,7 +59,7 @@ function App() {
     const newName = {name: text, id: uid(), createdAt: new Date(), source: "archive"};
     const newNames = [newName, ...archiveNames];
     setArchiveNames(newNames);
-    setSelectedIndex(0);
+    setJustAddedId(newName.id);
     navigate("/forest");
     saveToLocalStorage(newNames);
   }
@@ -79,7 +79,7 @@ function App() {
     try {
       const tree = await addCommunityTree(validation.name);
       setCommunityTrees((prev) => [tree, ...prev]);
-      setSelectedIndex(0);
+      setJustAddedId(tree.id);
       navigate("/forest");
     } catch (err) {
       setAddError(err.message ?? "Could not add your tree. Please try again.");
@@ -121,8 +121,8 @@ function App() {
               setArchiveNames={setArchiveNames}
               communityTrees={communityTrees}
               setCommunityTrees={setCommunityTrees}
-              selectedIndex={selectedIndex}
-              setSelectedIndex={setSelectedIndex}
+              justAddedId={justAddedId}
+              setJustAddedId={setJustAddedId}
             />
           }
         />

--- a/src/Forest.jsx
+++ b/src/Forest.jsx
@@ -97,7 +97,7 @@ function ForestSection({title, description, count, children}) {
   );
 }
 
-function ForestTreeCell({entry, isSelected, onClick, onDelete}) {
+function ForestTreeCell({entry, onClick, onDelete, animateEnter = false}) {
   const isOwn = entry.source === "community" && entry.browserId === getBrowserId();
 
   return (
@@ -107,7 +107,7 @@ function ForestTreeCell({entry, isSelected, onClick, onDelete}) {
         onClick={onClick}
         options={{padding: 0, number: false}}
         style={{cursor: "pointer"}}
-        isSelected={isSelected}
+        animateEnter={animateEnter}
       />
       {isOwn && onDelete && (
         <button
@@ -138,12 +138,18 @@ export function Forest({
   setArchiveNames,
   communityTrees,
   setCommunityTrees,
-  selectedIndex,
-  setSelectedIndex,
+  justAddedId,
+  setJustAddedId,
 }) {
   const [selectedId, setSelectedId] = useState(null);
   const [loadState, setLoadState] = useState("idle");
   const [loadError, setLoadError] = useState("");
+
+  useEffect(() => {
+    if (!justAddedId) return;
+    const timer = setTimeout(() => setJustAddedId(null), 1500);
+    return () => clearTimeout(timer);
+  }, [justAddedId, setJustAddedId]);
 
   const displayNames = useMemo(
     () => [...communityTrees, ...archiveNames],
@@ -188,7 +194,6 @@ export function Forest({
       await deleteCommunityTree(id);
       setCommunityTrees((prev) => prev.filter((t) => t.id !== id));
       setSelectedId(null);
-      setSelectedIndex(-1);
     } catch (err) {
       alert(err.message ?? "Could not delete your tree.");
     }
@@ -213,7 +218,6 @@ export function Forest({
       setArchiveNames(newNames);
       saveToLocalStorage(newNames);
       setSelectedId(null);
-      setSelectedIndex(-1);
     }
   };
 
@@ -240,7 +244,7 @@ export function Forest({
         <ForestTreeCell
           key={entry.source === "community" ? entry.id : entry.id || entry.name || globalIndex}
           entry={entry}
-          isSelected={globalIndex === selectedIndex || entry.id === selectedId}
+          animateEnter={justAddedId != null && entry.id === justAddedId}
           onClick={() => onClickTree(entry.id, globalIndex)}
           onDelete={
             entry.source === "community" && entry.browserId === getBrowserId()

--- a/src/TreeItem.jsx
+++ b/src/TreeItem.jsx
@@ -1,7 +1,7 @@
 import {useEffect, useRef} from "react";
 import {tree} from "./drawTree.js";
 
-export function TreeItem({name, onClick, options = {}, style = {}, isSelected = false}) {
+export function TreeItem({name, onClick, options = {}, style = {}, animateEnter = false}) {
   const treeRef = useRef(null);
 
   useEffect(() => {
@@ -20,7 +20,7 @@ export function TreeItem({name, onClick, options = {}, style = {}, isSelected = 
       ref={treeRef}
       style={{
         ...style,
-        animation: isSelected ? "fadeIn 1.5s ease-in-out" : "none",
+        animation: animateEnter ? "fadeIn 1.5s ease-in-out" : undefined,
       }}
       onClick={onClick}
     />


### PR DESCRIPTION
## Summary
- Clicking a tree on `/forest` no longer triggers the enter (scale/fade) animation.
- Newly added community or archive trees still play the enter animation once via a short-lived `justAddedId`.
- Selection/modal behavior is unchanged; animation is no longer tied to selection.

## Test plan
- [ ] Open `/forest`, click several existing trees — modal opens, grid trees do not animate
- [ ] From home, add a community tree — navigate to forest and confirm only that tree plays enter animation
- [ ] (Admin) Add an archive tree — confirm only that new tree animates
- [ ] Visit `/forest` without adding — no trees animate on load


Made with [Cursor](https://cursor.com)